### PR TITLE
[DEV-751] Machines and more tweaks

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -25,7 +25,7 @@
 * Add `phaseCode` to `UsagePoint` to record the phase data of the Usage Point.
 
 ### Fixes
-* Update java to superpom 0.36.2 (which brings dokka 1.9.20).
+* Update java to superpom 0.36.4 (which brings dokka 1.9.20).
 
 ### Notes
 * None.

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.zepben.maven</groupId>
         <artifactId>evolve-super-pom</artifactId>
-        <version>0.36.2</version>
+        <version>0.36.4</version>
     </parent>
 
     <groupId>com.zepben.protobuf</groupId>
@@ -132,20 +132,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.jetbrains.dokka</groupId>
-                <artifactId>dokka-maven-plugin</artifactId>
-                <version>${dokka.version}</version>
-                <configuration>
-                    <!-- This excludes all the generated code from the reference documentation.
-                    We don't really want any docs in this case as its not useful. -->
-                    <sourceDirectories>
-                        <dir>src</dir>
-                    </sourceDirectories>
-                </configuration>
-            </plugin>
-
-
         </plugins>
     </build>
 </project>

--- a/java/src/main/kotlin/com/zepben/protobuf/ZZZInternal.kt
+++ b/java/src/main/kotlin/com/zepben/protobuf/ZZZInternal.kt
@@ -1,0 +1,6 @@
+/**
+ * Empty file to make javadoc jar exist
+ */ 
+class ZZZInternal() {
+
+}

--- a/proto/zepben/proto.lock
+++ b/proto/zepben/proto.lock
@@ -10,32 +10,38 @@
               {
                 "id": 1,
                 "name": "organisation",
-                "type": "zepben.protobuf.cim.iec61968.common.Organisation"
+                "type": "zepben.protobuf.cim.iec61968.common.Organisation",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 2,
                 "name": "customer",
-                "type": "zepben.protobuf.cim.iec61968.customers.Customer"
+                "type": "zepben.protobuf.cim.iec61968.customers.Customer",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 3,
                 "name": "customerAgreement",
-                "type": "zepben.protobuf.cim.iec61968.customers.CustomerAgreement"
+                "type": "zepben.protobuf.cim.iec61968.customers.CustomerAgreement",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 4,
                 "name": "pricingStructure",
-                "type": "zepben.protobuf.cim.iec61968.customers.PricingStructure"
+                "type": "zepben.protobuf.cim.iec61968.customers.PricingStructure",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 5,
                 "name": "tariff",
-                "type": "zepben.protobuf.cim.iec61968.customers.Tariff"
+                "type": "zepben.protobuf.cim.iec61968.customers.Tariff",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 999,
                 "name": "other",
-                "type": "google.protobuf.Any"
+                "type": "google.protobuf.Any",
+                "oneof_parent": "identifiedObject"
               }
             ]
           }
@@ -2388,12 +2394,14 @@
               {
                 "id": 4,
                 "name": "recloseFastNull",
-                "type": "google.protobuf.NullValue"
+                "type": "google.protobuf.NullValue",
+                "oneof_parent": "recloseFast"
               },
               {
                 "id": 5,
                 "name": "recloseFastSet",
-                "type": "bool"
+                "type": "bool",
+                "oneof_parent": "recloseFast"
               }
             ]
           }
@@ -3458,22 +3466,22 @@
             "fields": [
               {
                 "id": 1,
-                "name": "xvalue",
+                "name": "xValue",
                 "type": "float"
               },
               {
                 "id": 2,
-                "name": "y1value",
+                "name": "y1Value",
                 "type": "float"
               },
               {
                 "id": 3,
-                "name": "y2value",
+                "name": "y2Value",
                 "type": "float"
               },
               {
                 "id": 4,
-                "name": "y3value",
+                "name": "y3Value",
                 "type": "float"
               }
             ]
@@ -5763,12 +5771,14 @@
               {
                 "id": 3,
                 "name": "inverseTimeFlagNull",
-                "type": "google.protobuf.NullValue"
+                "type": "google.protobuf.NullValue",
+                "oneof_parent": "inverseTimeFlag"
               },
               {
                 "id": 4,
                 "name": "inverseTimeFlagSet",
-                "type": "bool"
+                "type": "bool",
+                "oneof_parent": "inverseTimeFlag"
               },
               {
                 "id": 5,
@@ -5909,12 +5919,14 @@
               {
                 "id": 3,
                 "name": "reclosingNull",
-                "type": "google.protobuf.NullValue"
+                "type": "google.protobuf.NullValue",
+                "oneof_parent": "reclosing"
               },
               {
                 "id": 4,
                 "name": "reclosingSet",
-                "type": "bool"
+                "type": "bool",
+                "oneof_parent": "reclosing"
               },
               {
                 "id": 5,
@@ -5947,12 +5959,14 @@
               {
                 "id": 10,
                 "name": "directableNull",
-                "type": "google.protobuf.NullValue"
+                "type": "google.protobuf.NullValue",
+                "oneof_parent": "directable"
               },
               {
                 "id": 11,
                 "name": "directableSet",
-                "type": "bool"
+                "type": "bool",
+                "oneof_parent": "directable"
               },
               {
                 "id": 12,
@@ -7771,12 +7785,14 @@
               {
                 "id": 15,
                 "name": "invVoltWattRespModeNull",
-                "type": "google.protobuf.NullValue"
+                "type": "google.protobuf.NullValue",
+                "oneof_parent": "invVoltWattRespMode"
               },
               {
                 "id": 16,
                 "name": "invVoltWattRespModeSet",
-                "type": "bool"
+                "type": "bool",
+                "oneof_parent": "invVoltWattRespMode"
               },
               {
                 "id": 17,
@@ -7821,12 +7837,14 @@
               {
                 "id": 25,
                 "name": "invVoltVarRespModeNull",
-                "type": "google.protobuf.NullValue"
+                "type": "google.protobuf.NullValue",
+                "oneof_parent": "invVoltVarRespMode"
               },
               {
                 "id": 26,
                 "name": "invVoltVarRespModeSet",
-                "type": "bool"
+                "type": "bool",
+                "oneof_parent": "invVoltVarRespMode"
               },
               {
                 "id": 27,
@@ -7871,12 +7889,14 @@
               {
                 "id": 35,
                 "name": "invReactivePowerModeNull",
-                "type": "google.protobuf.NullValue"
+                "type": "google.protobuf.NullValue",
+                "oneof_parent": "invReactivePowerMode"
               },
               {
                 "id": 36,
                 "name": "invReactivePowerModeSet",
-                "type": "bool"
+                "type": "bool",
+                "oneof_parent": "invReactivePowerMode"
               },
               {
                 "id": 37,
@@ -8406,12 +8426,14 @@
               {
                 "id": 2,
                 "name": "discreteNull",
-                "type": "google.protobuf.NullValue"
+                "type": "google.protobuf.NullValue",
+                "oneof_parent": "discrete"
               },
               {
                 "id": 3,
                 "name": "discreteSet",
-                "type": "bool"
+                "type": "bool",
+                "oneof_parent": "discrete"
               },
               {
                 "id": 4,
@@ -8436,12 +8458,14 @@
               {
                 "id": 8,
                 "name": "enabledNull",
-                "type": "google.protobuf.NullValue"
+                "type": "google.protobuf.NullValue",
+                "oneof_parent": "enabled"
               },
               {
                 "id": 9,
                 "name": "enabledSet",
-                "type": "bool"
+                "type": "bool",
+                "oneof_parent": "enabled"
               },
               {
                 "id": 10,
@@ -8594,7 +8618,7 @@
               {
                 "id": 4,
                 "name": "ratedU",
-                "type": "double"
+                "type": "int32"
               },
               {
                 "id": 5,
@@ -9206,12 +9230,14 @@
               {
                 "id": 3,
                 "name": "lineDropCompensationNull",
-                "type": "google.protobuf.NullValue"
+                "type": "google.protobuf.NullValue",
+                "oneof_parent": "lineDropCompensation"
               },
               {
                 "id": 4,
                 "name": "lineDropCompensationSet",
-                "type": "bool"
+                "type": "bool",
+                "oneof_parent": "lineDropCompensation"
               },
               {
                 "id": 5,
@@ -9236,12 +9262,14 @@
               {
                 "id": 9,
                 "name": "forwardLDCBlockingNull",
-                "type": "google.protobuf.NullValue"
+                "type": "google.protobuf.NullValue",
+                "oneof_parent": "forwardLDCBlocking"
               },
               {
                 "id": 10,
                 "name": "forwardLDCBlockingSet",
-                "type": "bool"
+                "type": "bool",
+                "oneof_parent": "forwardLDCBlocking"
               },
               {
                 "id": 11,
@@ -9251,12 +9279,14 @@
               {
                 "id": 12,
                 "name": "coGenerationEnabledNull",
-                "type": "google.protobuf.NullValue"
+                "type": "google.protobuf.NullValue",
+                "oneof_parent": "coGenerationEnabled"
               },
               {
                 "id": 13,
                 "name": "coGenerationEnabledSet",
-                "type": "bool"
+                "type": "bool",
+                "oneof_parent": "coGenerationEnabled"
               }
             ]
           }
@@ -10612,17 +10642,20 @@
               {
                 "id": 1,
                 "name": "diagram",
-                "type": "zepben.protobuf.cim.iec61970.base.diagramlayout.Diagram"
+                "type": "zepben.protobuf.cim.iec61970.base.diagramlayout.Diagram",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 2,
                 "name": "diagramObject",
-                "type": "zepben.protobuf.cim.iec61970.base.diagramlayout.DiagramObject"
+                "type": "zepben.protobuf.cim.iec61970.base.diagramlayout.DiagramObject",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 999,
                 "name": "other",
-                "type": "google.protobuf.Any"
+                "type": "google.protobuf.Any",
+                "oneof_parent": "identifiedObject"
               }
             ]
           }
@@ -11013,12 +11046,14 @@
               {
                 "id": 3,
                 "name": "yearNull",
-                "type": "google.protobuf.NullValue"
+                "type": "google.protobuf.NullValue",
+                "oneof_parent": "year"
               },
               {
                 "id": 4,
                 "name": "yearSet",
-                "type": "int32"
+                "type": "int32",
+                "oneof_parent": "year"
               },
               {
                 "id": 5,
@@ -11028,12 +11063,14 @@
               {
                 "id": 6,
                 "name": "timeStepNull",
-                "type": "google.protobuf.NullValue"
+                "type": "google.protobuf.NullValue",
+                "oneof_parent": "timeStep"
               },
               {
                 "id": 7,
                 "name": "timeStepSet",
-                "type": "google.protobuf.Timestamp"
+                "type": "google.protobuf.Timestamp",
+                "oneof_parent": "timeStep"
               },
               {
                 "id": 8,
@@ -11166,12 +11203,14 @@
               {
                 "id": 9,
                 "name": "fixedTime",
-                "type": "FixedTime"
+                "type": "FixedTime",
+                "oneof_parent": "modelTime"
               },
               {
                 "id": 10,
                 "name": "timePeriod",
-                "type": "TimePeriod"
+                "type": "TimePeriod",
+                "oneof_parent": "modelTime"
               },
               {
                 "id": 11,
@@ -11508,12 +11547,14 @@
               {
                 "id": 11,
                 "name": "fixedTime",
-                "type": "FixedTime"
+                "type": "FixedTime",
+                "oneof_parent": "modelTime"
               },
               {
                 "id": 12,
                 "name": "timePeriod",
-                "type": "TimePeriod"
+                "type": "TimePeriod",
+                "oneof_parent": "modelTime"
               },
               {
                 "id": 13,
@@ -12587,12 +12628,14 @@
               {
                 "id": 1,
                 "name": "modelNull",
-                "type": "google.protobuf.NullValue"
+                "type": "google.protobuf.NullValue",
+                "oneof_parent": "model"
               },
               {
                 "id": 2,
                 "name": "modelSet",
-                "type": "Model"
+                "type": "Model",
+                "oneof_parent": "model"
               }
             ]
           },
@@ -12665,67 +12708,80 @@
               {
                 "id": 1,
                 "name": "di",
-                "type": "DemandIntervalReport"
+                "type": "DemandIntervalReport",
+                "oneof_parent": "report"
               },
               {
                 "id": 2,
                 "name": "phv",
-                "type": "PhaseVoltageReport"
+                "type": "PhaseVoltageReport",
+                "oneof_parent": "report"
               },
               {
                 "id": 3,
                 "name": "ov",
-                "type": "OverloadReport"
+                "type": "OverloadReport",
+                "oneof_parent": "report"
               },
               {
                 "id": 4,
                 "name": "vr",
-                "type": "VoltageReport"
+                "type": "VoltageReport",
+                "oneof_parent": "report"
               },
               {
                 "id": 5,
                 "name": "sr",
-                "type": "SummaryReport"
+                "type": "SummaryReport",
+                "oneof_parent": "report"
               },
               {
                 "id": 6,
                 "name": "el",
-                "type": "EventLog"
+                "type": "EventLog",
+                "oneof_parent": "report"
               },
               {
                 "id": 7,
                 "name": "tr",
-                "type": "TapsReport"
+                "type": "TapsReport",
+                "oneof_parent": "report"
               },
               {
                 "id": 8,
                 "name": "lr",
-                "type": "LoopReport"
+                "type": "LoopReport",
+                "oneof_parent": "report"
               },
               {
                 "id": 9,
                 "name": "ibr",
-                "type": "IsolatedBusesReport"
+                "type": "IsolatedBusesReport",
+                "oneof_parent": "report"
               },
               {
                 "id": 10,
                 "name": "le",
-                "type": "LossesEntry"
+                "type": "LossesEntry",
+                "oneof_parent": "report"
               },
               {
                 "id": 11,
                 "name": "losses",
-                "type": "LossesTotals"
+                "type": "LossesTotals",
+                "oneof_parent": "report"
               },
               {
                 "id": 12,
                 "name": "nm",
-                "type": "NodeMismatch"
+                "type": "NodeMismatch",
+                "oneof_parent": "report"
               },
               {
                 "id": 13,
                 "name": "kvm",
-                "type": "KVBaseMismatch"
+                "type": "KVBaseMismatch",
+                "oneof_parent": "report"
               }
             ]
           }
@@ -13370,17 +13426,20 @@
               {
                 "id": 1,
                 "name": "accumulatorValue",
-                "type": "cim.iec61970.base.meas.AccumulatorValue"
+                "type": "cim.iec61970.base.meas.AccumulatorValue",
+                "oneof_parent": "value"
               },
               {
                 "id": 2,
                 "name": "analogValue",
-                "type": "cim.iec61970.base.meas.AnalogValue"
+                "type": "cim.iec61970.base.meas.AnalogValue",
+                "oneof_parent": "value"
               },
               {
                 "id": 3,
                 "name": "discreteValue",
-                "type": "cim.iec61970.base.meas.DiscreteValue"
+                "type": "cim.iec61970.base.meas.DiscreteValue",
+                "oneof_parent": "value"
               },
               {
                 "id": 4,
@@ -13525,407 +13584,488 @@
               {
                 "id": 1,
                 "name": "cableInfo",
-                "type": "zepben.protobuf.cim.iec61968.assetinfo.CableInfo"
+                "type": "zepben.protobuf.cim.iec61968.assetinfo.CableInfo",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 2,
                 "name": "overheadWireInfo",
-                "type": "zepben.protobuf.cim.iec61968.assetinfo.OverheadWireInfo"
+                "type": "zepben.protobuf.cim.iec61968.assetinfo.OverheadWireInfo",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 3,
                 "name": "assetOwner",
-                "type": "zepben.protobuf.cim.iec61968.assets.AssetOwner"
+                "type": "zepben.protobuf.cim.iec61968.assets.AssetOwner",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 4,
                 "name": "organisation",
-                "type": "zepben.protobuf.cim.iec61968.common.Organisation"
+                "type": "zepben.protobuf.cim.iec61968.common.Organisation",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 5,
                 "name": "location",
-                "type": "zepben.protobuf.cim.iec61968.common.Location"
+                "type": "zepben.protobuf.cim.iec61968.common.Location",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 6,
                 "name": "meter",
-                "type": "zepben.protobuf.cim.iec61968.metering.Meter"
+                "type": "zepben.protobuf.cim.iec61968.metering.Meter",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 7,
                 "name": "usagePoint",
-                "type": "zepben.protobuf.cim.iec61968.metering.UsagePoint"
+                "type": "zepben.protobuf.cim.iec61968.metering.UsagePoint",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 8,
                 "name": "operationalRestriction",
-                "type": "zepben.protobuf.cim.iec61968.operations.OperationalRestriction"
+                "type": "zepben.protobuf.cim.iec61968.operations.OperationalRestriction",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 9,
                 "name": "faultIndicator",
-                "type": "zepben.protobuf.cim.iec61970.base.auxiliaryequipment.FaultIndicator"
+                "type": "zepben.protobuf.cim.iec61970.base.auxiliaryequipment.FaultIndicator",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 10,
                 "name": "baseVoltage",
-                "type": "zepben.protobuf.cim.iec61970.base.core.BaseVoltage"
+                "type": "zepben.protobuf.cim.iec61970.base.core.BaseVoltage",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 11,
                 "name": "connectivityNode",
-                "type": "zepben.protobuf.cim.iec61970.base.core.ConnectivityNode"
+                "type": "zepben.protobuf.cim.iec61970.base.core.ConnectivityNode",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 12,
                 "name": "feeder",
-                "type": "zepben.protobuf.cim.iec61970.base.core.Feeder"
+                "type": "zepben.protobuf.cim.iec61970.base.core.Feeder",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 13,
                 "name": "geographicalRegion",
-                "type": "zepben.protobuf.cim.iec61970.base.core.GeographicalRegion"
+                "type": "zepben.protobuf.cim.iec61970.base.core.GeographicalRegion",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 14,
                 "name": "site",
-                "type": "zepben.protobuf.cim.iec61970.base.core.Site"
+                "type": "zepben.protobuf.cim.iec61970.base.core.Site",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 15,
                 "name": "subGeographicalRegion",
-                "type": "zepben.protobuf.cim.iec61970.base.core.SubGeographicalRegion"
+                "type": "zepben.protobuf.cim.iec61970.base.core.SubGeographicalRegion",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 16,
                 "name": "substation",
-                "type": "zepben.protobuf.cim.iec61970.base.core.Substation"
+                "type": "zepben.protobuf.cim.iec61970.base.core.Substation",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 17,
                 "name": "terminal",
-                "type": "zepben.protobuf.cim.iec61970.base.core.Terminal"
+                "type": "zepben.protobuf.cim.iec61970.base.core.Terminal",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 18,
                 "name": "acLineSegment",
-                "type": "zepben.protobuf.cim.iec61970.base.wires.AcLineSegment"
+                "type": "zepben.protobuf.cim.iec61970.base.wires.AcLineSegment",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 19,
                 "name": "breaker",
-                "type": "zepben.protobuf.cim.iec61970.base.wires.Breaker"
+                "type": "zepben.protobuf.cim.iec61970.base.wires.Breaker",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 20,
                 "name": "disconnector",
-                "type": "zepben.protobuf.cim.iec61970.base.wires.Disconnector"
+                "type": "zepben.protobuf.cim.iec61970.base.wires.Disconnector",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 21,
                 "name": "energyConsumer",
-                "type": "zepben.protobuf.cim.iec61970.base.wires.EnergyConsumer"
+                "type": "zepben.protobuf.cim.iec61970.base.wires.EnergyConsumer",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 22,
                 "name": "energyConsumerPhase",
-                "type": "zepben.protobuf.cim.iec61970.base.wires.EnergyConsumerPhase"
+                "type": "zepben.protobuf.cim.iec61970.base.wires.EnergyConsumerPhase",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 23,
                 "name": "energySource",
-                "type": "zepben.protobuf.cim.iec61970.base.wires.EnergySource"
+                "type": "zepben.protobuf.cim.iec61970.base.wires.EnergySource",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 24,
                 "name": "energySourcePhase",
-                "type": "zepben.protobuf.cim.iec61970.base.wires.EnergySourcePhase"
+                "type": "zepben.protobuf.cim.iec61970.base.wires.EnergySourcePhase",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 25,
                 "name": "fuse",
-                "type": "zepben.protobuf.cim.iec61970.base.wires.Fuse"
+                "type": "zepben.protobuf.cim.iec61970.base.wires.Fuse",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 26,
                 "name": "jumper",
-                "type": "zepben.protobuf.cim.iec61970.base.wires.Jumper"
+                "type": "zepben.protobuf.cim.iec61970.base.wires.Jumper",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 27,
                 "name": "junction",
-                "type": "zepben.protobuf.cim.iec61970.base.wires.Junction"
+                "type": "zepben.protobuf.cim.iec61970.base.wires.Junction",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 28,
                 "name": "linearShuntCompensator",
-                "type": "zepben.protobuf.cim.iec61970.base.wires.LinearShuntCompensator"
+                "type": "zepben.protobuf.cim.iec61970.base.wires.LinearShuntCompensator",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 29,
                 "name": "perLengthSequenceImpedance",
-                "type": "zepben.protobuf.cim.iec61970.base.wires.PerLengthSequenceImpedance"
+                "type": "zepben.protobuf.cim.iec61970.base.wires.PerLengthSequenceImpedance",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 30,
                 "name": "powerTransformer",
-                "type": "zepben.protobuf.cim.iec61970.base.wires.PowerTransformer"
+                "type": "zepben.protobuf.cim.iec61970.base.wires.PowerTransformer",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 31,
                 "name": "powerTransformerEnd",
-                "type": "zepben.protobuf.cim.iec61970.base.wires.PowerTransformerEnd"
+                "type": "zepben.protobuf.cim.iec61970.base.wires.PowerTransformerEnd",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 32,
                 "name": "ratioTapChanger",
-                "type": "zepben.protobuf.cim.iec61970.base.wires.RatioTapChanger"
+                "type": "zepben.protobuf.cim.iec61970.base.wires.RatioTapChanger",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 33,
                 "name": "recloser",
-                "type": "zepben.protobuf.cim.iec61970.base.wires.Recloser"
+                "type": "zepben.protobuf.cim.iec61970.base.wires.Recloser",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 34,
                 "name": "circuit",
-                "type": "zepben.protobuf.cim.iec61970.infiec61970.feeder.Circuit"
+                "type": "zepben.protobuf.cim.iec61970.infiec61970.feeder.Circuit",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 35,
                 "name": "loop",
-                "type": "zepben.protobuf.cim.iec61970.infiec61970.feeder.Loop"
+                "type": "zepben.protobuf.cim.iec61970.infiec61970.feeder.Loop",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 36,
                 "name": "pole",
-                "type": "zepben.protobuf.cim.iec61968.assets.Pole"
+                "type": "zepben.protobuf.cim.iec61968.assets.Pole",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 37,
                 "name": "streetlight",
-                "type": "zepben.protobuf.cim.iec61968.assets.Streetlight"
+                "type": "zepben.protobuf.cim.iec61968.assets.Streetlight",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 38,
                 "name": "accumulator",
-                "type": "zepben.protobuf.cim.iec61970.base.meas.Accumulator"
+                "type": "zepben.protobuf.cim.iec61970.base.meas.Accumulator",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 39,
                 "name": "analog",
-                "type": "zepben.protobuf.cim.iec61970.base.meas.Analog"
+                "type": "zepben.protobuf.cim.iec61970.base.meas.Analog",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 40,
                 "name": "discrete",
-                "type": "zepben.protobuf.cim.iec61970.base.meas.Discrete"
+                "type": "zepben.protobuf.cim.iec61970.base.meas.Discrete",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 41,
                 "name": "control",
-                "type": "zepben.protobuf.cim.iec61970.base.meas.Control"
+                "type": "zepben.protobuf.cim.iec61970.base.meas.Control",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 42,
                 "name": "remoteControl",
-                "type": "zepben.protobuf.cim.iec61970.base.scada.RemoteControl"
+                "type": "zepben.protobuf.cim.iec61970.base.scada.RemoteControl",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 43,
                 "name": "remoteSource",
-                "type": "zepben.protobuf.cim.iec61970.base.scada.RemoteSource"
+                "type": "zepben.protobuf.cim.iec61970.base.scada.RemoteSource",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 44,
                 "name": "powerTransformerInfo",
-                "type": "zepben.protobuf.cim.iec61968.assetinfo.PowerTransformerInfo"
+                "type": "zepben.protobuf.cim.iec61968.assetinfo.PowerTransformerInfo",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 45,
                 "name": "powerElectronicsConnection",
-                "type": "zepben.protobuf.cim.iec61970.base.wires.PowerElectronicsConnection"
+                "type": "zepben.protobuf.cim.iec61970.base.wires.PowerElectronicsConnection",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 46,
                 "name": "powerElectronicsConnectionPhase",
-                "type": "zepben.protobuf.cim.iec61970.base.wires.PowerElectronicsConnectionPhase"
+                "type": "zepben.protobuf.cim.iec61970.base.wires.PowerElectronicsConnectionPhase",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 47,
                 "name": "batteryUnit",
-                "type": "zepben.protobuf.cim.iec61970.base.wires.generation.production.BatteryUnit"
+                "type": "zepben.protobuf.cim.iec61970.base.wires.generation.production.BatteryUnit",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 48,
                 "name": "photoVoltaicUnit",
-                "type": "zepben.protobuf.cim.iec61970.base.wires.generation.production.PhotoVoltaicUnit"
+                "type": "zepben.protobuf.cim.iec61970.base.wires.generation.production.PhotoVoltaicUnit",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 49,
                 "name": "powerElectronicsWindUnit",
-                "type": "zepben.protobuf.cim.iec61970.base.wires.generation.production.PowerElectronicsWindUnit"
+                "type": "zepben.protobuf.cim.iec61970.base.wires.generation.production.PowerElectronicsWindUnit",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 50,
                 "name": "busbarSection",
-                "type": "zepben.protobuf.cim.iec61970.base.wires.BusbarSection"
+                "type": "zepben.protobuf.cim.iec61970.base.wires.BusbarSection",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 51,
                 "name": "loadBreakSwitch",
-                "type": "zepben.protobuf.cim.iec61970.base.wires.LoadBreakSwitch"
+                "type": "zepben.protobuf.cim.iec61970.base.wires.LoadBreakSwitch",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 52,
                 "name": "transformerStarImpedance",
-                "type": "zepben.protobuf.cim.iec61970.base.wires.TransformerStarImpedance"
+                "type": "zepben.protobuf.cim.iec61970.base.wires.TransformerStarImpedance",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 53,
                 "name": "transformerEndInfo",
-                "type": "zepben.protobuf.cim.iec61968.assetinfo.TransformerEndInfo"
+                "type": "zepben.protobuf.cim.iec61968.assetinfo.TransformerEndInfo",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 54,
                 "name": "transformerTankInfo",
-                "type": "zepben.protobuf.cim.iec61968.assetinfo.TransformerTankInfo"
+                "type": "zepben.protobuf.cim.iec61968.assetinfo.TransformerTankInfo",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 55,
                 "name": "noLoadTest",
-                "type": "zepben.protobuf.cim.iec61968.assetinfo.NoLoadTest"
+                "type": "zepben.protobuf.cim.iec61968.assetinfo.NoLoadTest",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 56,
                 "name": "openCircuitTest",
-                "type": "zepben.protobuf.cim.iec61968.assetinfo.OpenCircuitTest"
+                "type": "zepben.protobuf.cim.iec61968.assetinfo.OpenCircuitTest",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 57,
                 "name": "shortCircuitTest",
-                "type": "zepben.protobuf.cim.iec61968.assetinfo.ShortCircuitTest"
+                "type": "zepben.protobuf.cim.iec61968.assetinfo.ShortCircuitTest",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 58,
                 "name": "equivalentBranch",
-                "type": "zepben.protobuf.cim.iec61970.base.equivalents.EquivalentBranch"
+                "type": "zepben.protobuf.cim.iec61970.base.equivalents.EquivalentBranch",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 59,
                 "name": "shuntCompensatorInfo",
-                "type": "zepben.protobuf.cim.iec61968.assetinfo.ShuntCompensatorInfo"
+                "type": "zepben.protobuf.cim.iec61968.assetinfo.ShuntCompensatorInfo",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 60,
                 "name": "lvFeeder",
-                "type": "zepben.protobuf.cim.iec61970.infiec61970.feeder.LvFeeder"
+                "type": "zepben.protobuf.cim.iec61970.infiec61970.feeder.LvFeeder",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 61,
                 "name": "currentTransformer",
-                "type": "zepben.protobuf.cim.iec61970.base.auxiliaryequipment.CurrentTransformer"
+                "type": "zepben.protobuf.cim.iec61970.base.auxiliaryequipment.CurrentTransformer",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 62,
                 "name": "potentialTransformer",
-                "type": "zepben.protobuf.cim.iec61970.base.auxiliaryequipment.PotentialTransformer"
+                "type": "zepben.protobuf.cim.iec61970.base.auxiliaryequipment.PotentialTransformer",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 63,
                 "name": "currentTransformerInfo",
-                "type": "zepben.protobuf.cim.iec61968.infiec61968.infassetinfo.CurrentTransformerInfo"
+                "type": "zepben.protobuf.cim.iec61968.infiec61968.infassetinfo.CurrentTransformerInfo",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 64,
                 "name": "potentialTransformerInfo",
-                "type": "zepben.protobuf.cim.iec61968.infiec61968.infassetinfo.PotentialTransformerInfo"
+                "type": "zepben.protobuf.cim.iec61968.infiec61968.infassetinfo.PotentialTransformerInfo",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 65,
                 "name": "switchInfo",
-                "type": "zepben.protobuf.cim.iec61968.assetinfo.SwitchInfo"
+                "type": "zepben.protobuf.cim.iec61968.assetinfo.SwitchInfo",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 66,
                 "name": "relayInfo",
-                "type": "zepben.protobuf.cim.iec61968.infiec61968.infassetinfo.RelayInfo"
+                "type": "zepben.protobuf.cim.iec61968.infiec61968.infassetinfo.RelayInfo",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 68,
                 "name": "currentRelay",
-                "type": "zepben.protobuf.cim.iec61970.base.protection.CurrentRelay"
+                "type": "zepben.protobuf.cim.iec61970.base.protection.CurrentRelay",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 69,
                 "name": "tapChangerControl",
-                "type": "zepben.protobuf.cim.iec61970.base.wires.TapChangerControl"
+                "type": "zepben.protobuf.cim.iec61970.base.wires.TapChangerControl",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 70,
                 "name": "evChargingUnit",
-                "type": "zepben.protobuf.cim.iec61970.infiec61970.wires.generation.production.EvChargingUnit"
+                "type": "zepben.protobuf.cim.iec61970.infiec61970.wires.generation.production.EvChargingUnit",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 71,
                 "name": "seriesCompensator",
-                "type": "zepben.protobuf.cim.iec61970.base.wires.SeriesCompensator"
+                "type": "zepben.protobuf.cim.iec61970.base.wires.SeriesCompensator",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 72,
                 "name": "ground",
-                "type": "zepben.protobuf.cim.iec61970.base.wires.Ground"
+                "type": "zepben.protobuf.cim.iec61970.base.wires.Ground",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 73,
                 "name": "groundDisconnector",
-                "type": "zepben.protobuf.cim.iec61970.base.wires.GroundDisconnector"
+                "type": "zepben.protobuf.cim.iec61970.base.wires.GroundDisconnector",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 74,
                 "name": "protectionRelayScheme",
-                "type": "zepben.protobuf.cim.iec61970.base.protection.ProtectionRelayScheme"
+                "type": "zepben.protobuf.cim.iec61970.base.protection.ProtectionRelayScheme",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 75,
                 "name": "protectionRelaySystem",
-                "type": "zepben.protobuf.cim.iec61970.base.protection.ProtectionRelaySystem"
+                "type": "zepben.protobuf.cim.iec61970.base.protection.ProtectionRelaySystem",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 76,
                 "name": "voltageRelay",
-                "type": "zepben.protobuf.cim.iec61970.base.protection.VoltageRelay"
+                "type": "zepben.protobuf.cim.iec61970.base.protection.VoltageRelay",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 77,
                 "name": "distanceRelay",
-                "type": "zepben.protobuf.cim.iec61970.base.protection.DistanceRelay"
+                "type": "zepben.protobuf.cim.iec61970.base.protection.DistanceRelay",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 78,
                 "name": "synchronousMachine",
-                "type": "zepben.protobuf.cim.iec61970.base.wires.SynchronousMachine"
+                "type": "zepben.protobuf.cim.iec61970.base.wires.SynchronousMachine",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 79,
                 "name": "reactiveCapabilityCurve",
-                "type": "zepben.protobuf.cim.iec61970.base.wires.ReactiveCapabilityCurve"
+                "type": "zepben.protobuf.cim.iec61970.base.wires.ReactiveCapabilityCurve",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 80,
                 "name": "groundingImpedance",
-                "type": "zepben.protobuf.cim.iec61970.base.wires.GroundingImpedance"
+                "type": "zepben.protobuf.cim.iec61970.base.wires.GroundingImpedance",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 81,
                 "name": "petersenCoil",
-                "type": "zepben.protobuf.cim.iec61970.base.wires.PetersenCoil"
+                "type": "zepben.protobuf.cim.iec61970.base.wires.PetersenCoil",
+                "oneof_parent": "identifiedObject"
               },
               {
                 "id": 999,
                 "name": "other",
-                "type": "google.protobuf.Any"
+                "type": "google.protobuf.Any",
+                "oneof_parent": "identifiedObject"
               }
             ]
           }

--- a/proto/zepben/protobuf/cim/iec61970/base/core/CurveData.proto
+++ b/proto/zepben/protobuf/cim/iec61970/base/core/CurveData.proto
@@ -22,21 +22,21 @@ message CurveData {
     /**
      * The data value of the X-axis variable, depending on the X-axis units.
      */
-    float xvalue = 1;
+    float xValue = 1;
 
     /**
      * The data value of the first Y-axis variable, depending on the Y-axis units.
      */
-    float y1value = 2;
+    float y1Value = 2;
 
     /**
      * The data value of the second Y-axis variable (if present), depending on the Y-axis units.
      */
-    float y2value = 3;
+    float y2Value = 3;
 
     /**
      * The data value of the third Y-axis variable (if present), depending on the Y-axis units.
      */
-    float y3value = 4;
+    float y3Value = 4;
 
 }

--- a/proto/zepben/protobuf/cim/iec61970/base/wires/RotatingMachine.proto
+++ b/proto/zepben/protobuf/cim/iec61970/base/wires/RotatingMachine.proto
@@ -38,7 +38,7 @@ message RotatingMachine {
     /**
      * Rated voltage in volts (nameplate data, Ur in IEC 60909-0). It is primarily used for short circuit data exchange according to IEC 60909. The attribute shall be a positive value.
      */
-    double ratedU = 4;
+    int32 ratedU = 4;
 
     /**
      * Active power injection in watts. Load sign convention is used, i.e. positive sign means flow out from a node. Starting value for a steady state solution.

--- a/spec/ewb/IEC61970/Base/Wires/RotatingMachine.yaml
+++ b/spec/ewb/IEC61970/Base/Wires/RotatingMachine.yaml
@@ -8,7 +8,7 @@ attributes:
   type: Double
   description: Nameplate apparent power rating for the unit in volt-amperes (VA). The attribute shall have a positive value.
 - name: ratedU
-  type: Double
+  type: Integer
   description: Rated voltage in volts (nameplate data, Ur in IEC 60909-0). It is primarily used for short circuit data exchange according to IEC 60909. 
     The attribute shall be a positive value.
 - name: p


### PR DESCRIPTION
# Description

Minor tweaks for the machines and more changes that were previously merged.
* Updated `RotatingMachine.ratedU` to be an integer (matching other rated voltage fields)
* Update `CurveData` fields casing to be consistent in the protobuf output which auto converted `y1value` to `y1Value` but didn't change `xvalue` to `xValue`

# Test Steps

Deploy it and see it in all its glory

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
~- [ ] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.~
~- [ ] I have commented my code in any hard-to-understand or hacky areas.~
~- [ ] I have handled all new warnings generated by the compiler or IDE.~
- [x] I have rebased onto the target branch (usually main).

### Documentation
~- [ ] I have updated the changelog.~ Updates to things already in the change log
~- [ ] I have updated any documentation required for these changes.~

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members if so.

Its all breaking, but nothing merged is using it yet so it should be all good.