### PR TITLE
[DEV-1442] Improve C libraries building (#107) [skip ci]

### DIFF
--- a/.github/workflows/build-c-container.yml
+++ b/.github/workflows/build-c-container.yml
@@ -1,0 +1,31 @@
+name: Create grpc-c-builder image
+
+on: workflow_dispatch
+
+jobs:
+  build_grpc_c_builder:
+    runs-on: ubuntu-latest
+    container:  hashicorp/packer:1.12
+    env:
+      REGISTRY: ${{ secrets.CONTAINER_REGISTRY }}
+      REGISTRY_USER: ${{ github.actor }}
+      REGISTRY_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Packer Version
+        run: |
+          packer version
+
+      - name: Create zepben/grpc-c-builder
+        run: |
+          apk add docker tar
+          mkdir /build
+          export PACKER_CONFIG_DIR=/build
+          cd c/builder-container
+          packer init alpine-protoc.pkr.hcl
+          packer validate alpine-protoc.pkr.hcl
+          packer build -on-error=abort alpine-protoc.pkr.hcl
+        shell: bash
+
+

--- a/README.md
+++ b/README.md
@@ -86,6 +86,17 @@ nuget init path/to/Zepben.Evolve.Grpc.<VERSION>.nupkg path/to/local/nuget/debug/
 
 ### C
 
+There are 2 ways to build packages locally:
+ * To build the libraries using a container, login to ghrc.io with your credentials, and run:
+
+```sh
+cd c
+make container-lib
+```
+  This will download the contaner zepben/grpc-c-builder and use it to build the libraries.
+
+ * Alternatively, to build libraries directly, install `protoc`, `grpc` and `make` packages, and run: 
+
 ```sh
 cd c
 make

--- a/c/Makefile
+++ b/c/Makefile
@@ -1,10 +1,16 @@
 # We only build the files used by the hosting capacity C library, as we are not interested in supporting C at this stage.
-PROTO_PATH = ../proto/zepben/protobuf
-HC_PATH = hc/opendss
+PROTO_PATH = ../proto
+HC_PATH = zepben/protobuf/hc/opendss
 FILES = Diagnostics \
         EnergyMeter \
         OpenDssReport
 
+TAG = 1.0.0
+DOCKER_BIN := $(shell { command -v podman || command -v docker ; } 2>/dev/null)
+
 all:
 	@mkdir -p out
 	protoc -I $(PROTO_PATH) --c_out=out $(foreach FILE,$(FILES),$(PROTO_PATH)/$(HC_PATH)/$(FILE).proto)
+
+container-lib:
+	$(DOCKER_BIN) run -v $(realpath ..):/app ghcr.io/zepben/grpc-c-builder:$(TAG) ash -c "cd /app/c && make"

--- a/c/builder-container/alpine-protoc.pkr.hcl
+++ b/c/builder-container/alpine-protoc.pkr.hcl
@@ -1,0 +1,55 @@
+packer {
+  required_plugins {
+    docker = {
+      source  = "github.com/hashicorp/docker"
+      version = "~> 1"
+    }
+  }
+}
+
+variable "tag" {
+    type = string
+    default = "1.0.0"
+}
+
+variable "registry_token" {
+  type    = string
+  default = "${env("REGISTRY_ACCESS_TOKEN")}"
+}
+
+variable "registry_user" {
+  type    = string
+  default = "${env("REGISTRY_USER")}"
+}
+
+variable "repository" {
+  type = string
+  default = "${env("REGISTRY")}/zepben/grpc-c-builder"
+}
+
+source "docker" "image" {
+  commit = "true"
+  image  = "alpine:3.20"
+}
+
+build {
+  sources = ["source.docker.image"]
+
+  provisioner "shell" {
+    inline = ["apk add grpc protoc protobuf-c-compiler make"]
+  }
+
+  post-processors {
+    post-processor "docker-tag" {
+      name       = "docker.tag"
+      repository = "${var.repository}"
+      tags       = [${var.tag}]
+    }
+    post-processor "docker-push" {
+      name           = "docker.push"
+      login           = true
+      login_password = "${var.registry_token}"
+      login_username = "${var.registry_user}"
+    }
+  }
+}

--- a/changelog.md
+++ b/changelog.md
@@ -23,6 +23,8 @@
 
 ### Enhancements
 * Add `phaseCode` to `UsagePoint` to record the phase data of the Usage Point.
+* Add docker-based C lib bulder;
+* Add `make container-lib` option to build Hosting Capacity C libraries in a container
 
 ### Fixes
 * Update java to superpom 0.36.4 (which brings dokka 1.9.20).


### PR DESCRIPTION
# Description

To simplify building C libraries (currently for HC), the following improvements were made:
 
* Update Makefile to follow directory structure.
* Create alpine-based container with `protoc` and related tools
* Add a CI workflow to build and deploy the `grpc-c-builder` container
* Add `make container-lib` option to build libs with container
* Update README.md with instructions to use the container to build C libraries.
* Changelog update

# Test Steps

After deploying the builder container use instructions in README to build C libraries.

# Checklist

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [ ] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [ ] I have commented my code in any hard-to-understand or hacky areas.
- [ ] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).

### Documentation
- [x] I have updated the changelog.
- [x] I have updated any documentation required for these changes.

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members if so.