### PR TITLE
[DEV-1533] `Switch.ratedCurrent` and `SynchronousMachine.reactiveCapabilityCurveMRIDs` fixes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 ## [0.31.0] - UNRELEASED
 ### Breaking Changes
 * Updated the hosting capacity 'Job' and 'Syf' protos to support the configuration for the generator, executor, and result processor modules be passed as base64 encoded json objects.
+* `Switch.ratedCurrent` has been converted to a `double` (used to be an `integer`). Type safe languages will need to be updated to support floating point arithmatic/syntax.
 
 ### New Features
 * Added New Classes

--- a/proto/zepben/proto.lock
+++ b/proto/zepben/proto.lock
@@ -6154,9 +6154,6 @@
         ],
         "imports": [
           {
-            "path": "zepben/protobuf/cim/iec61970/base/core/IdentifiedObject.proto"
-          },
-          {
             "path": "zepben/protobuf/cim/iec61970/base/domain/UnitSymbol.proto"
           }
         ],
@@ -8881,7 +8878,7 @@
               {
                 "id": 4,
                 "name": "ratedCurrent",
-                "type": "uint32"
+                "type": "double"
               }
             ]
           }
@@ -9030,7 +9027,7 @@
               {
                 "id": 23,
                 "name": "reactiveCapabilityCurveMRIDs",
-                "type": "ReactiveCapabilityCurve",
+                "type": "string",
                 "is_repeated": true
               }
             ]
@@ -9042,9 +9039,6 @@
           },
           {
             "path": "zepben/protobuf/cim/iec61970/base/wires/SynchronousMachineKind.proto"
-          },
-          {
-            "path": "zepben/protobuf/cim/iec61970/base/wires/ReactiveCapabilityCurve.proto"
           }
         ],
         "package": {
@@ -13756,9 +13750,6 @@
           },
           {
             "path": "zepben/protobuf/cim/iec61970/base/protection/ProtectionRelaySystem.proto"
-          },
-          {
-            "path": "zepben/protobuf/cim/iec61970/base/protection/RelaySetting.proto"
           },
           {
             "path": "zepben/protobuf/cim/iec61970/base/protection/VoltageRelay.proto"

--- a/proto/zepben/protobuf/cim/iec61970/base/protection/RelaySetting.proto
+++ b/proto/zepben/protobuf/cim/iec61970/base/protection/RelaySetting.proto
@@ -12,7 +12,6 @@ option java_package = "com.zepben.protobuf.cim.iec61970.base.protection";
 option csharp_namespace = "Zepben.Protobuf.CIM.IEC61970.Base.Protection";
 package zepben.protobuf.cim.iec61970.base.protection;
 
-import "zepben/protobuf/cim/iec61970/base/core/IdentifiedObject.proto";
 import "zepben/protobuf/cim/iec61970/base/domain/UnitSymbol.proto";
 
 /**

--- a/proto/zepben/protobuf/cim/iec61970/base/wires/Switch.proto
+++ b/proto/zepben/protobuf/cim/iec61970/base/wires/Switch.proto
@@ -40,6 +40,6 @@ message Switch {
      * The maximum continuous current carrying capacity in amps governed by the device material and construction.
      * The attribute shall be a positive value.
      */
-    uint32 ratedCurrent = 4;
+    double ratedCurrent = 4;
 
 }

--- a/proto/zepben/protobuf/cim/iec61970/base/wires/SynchronousMachine.proto
+++ b/proto/zepben/protobuf/cim/iec61970/base/wires/SynchronousMachine.proto
@@ -15,7 +15,6 @@ package zepben.protobuf.cim.iec61970.base.wires;
 
 import "zepben/protobuf/cim/iec61970/base/wires/RotatingMachine.proto";
 import "zepben/protobuf/cim/iec61970/base/wires/SynchronousMachineKind.proto";
-import "zepben/protobuf/cim/iec61970/base/wires/ReactiveCapabilityCurve.proto";
 
 /**
  * An electromechanical device that operates with shaft rotating synchronously with the network. It is a single machine operating either as a generator or

--- a/proto/zepben/protobuf/cim/iec61970/base/wires/SynchronousMachine.proto
+++ b/proto/zepben/protobuf/cim/iec61970/base/wires/SynchronousMachine.proto
@@ -140,6 +140,6 @@ message SynchronousMachine {
     /**
      * The available reactive capability curves for this synchronous machine. The first shall be the default for this SynchronousMachine.
      */
-    repeated ReactiveCapabilityCurve reactiveCapabilityCurveMRIDs = 23;
+    repeated string reactiveCapabilityCurveMRIDs = 23;
 
 }

--- a/proto/zepben/protobuf/nc/nc-data.proto
+++ b/proto/zepben/protobuf/nc/nc-data.proto
@@ -87,7 +87,6 @@ import "zepben/protobuf/cim/iec61970/base/wires/Ground.proto";
 import "zepben/protobuf/cim/iec61970/base/wires/GroundDisconnector.proto";
 import "zepben/protobuf/cim/iec61970/base/protection/ProtectionRelayScheme.proto";
 import "zepben/protobuf/cim/iec61970/base/protection/ProtectionRelaySystem.proto";
-import "zepben/protobuf/cim/iec61970/base/protection/RelaySetting.proto";
 import "zepben/protobuf/cim/iec61970/base/protection/VoltageRelay.proto";
 import "zepben/protobuf/cim/iec61970/base/protection/DistanceRelay.proto";
 import "zepben/protobuf/cim/iec61970/base/wires/SynchronousMachine.proto";

--- a/spec/ewb/IEC61970/Base/Wires/EarthFaultCompensator.yaml
+++ b/spec/ewb/IEC61970/Base/Wires/EarthFaultCompensator.yaml
@@ -4,10 +4,9 @@ description: A conducting equipment used to represent a connection to ground whi
   normal connection rules apply.
 attributes:
 - name: r
-  type: Double
+  type: Float
   description: Nominal resistance of device in ohms.
 ancestors:
 - ConductingEquipment
 descendants:
 - GroundingImpedance
-

--- a/spec/ewb/IEC61970/Base/Wires/GroundingImpedance.yaml
+++ b/spec/ewb/IEC61970/Base/Wires/GroundingImpedance.yaml
@@ -2,8 +2,7 @@ name: GroundingImpedance
 description: A fixed impedance device used for grounding.
 attributes:
 - name: x
-  type: Double
+  type: Float
   description: Reactance of device in ohms.
 ancestors:
 - GroundingImpedance
-

--- a/spec/ewb/IEC61970/Base/Wires/PetersenCoil.yaml
+++ b/spec/ewb/IEC61970/Base/Wires/PetersenCoil.yaml
@@ -2,9 +2,8 @@ name: PetersenCoil
 description: A variable impedance device normally used to offset line charging during single line faults in an ungrounded section of network.
 attributes:
 - name: xGroundNominal
-  type: Double
+  type: Float
   description: The nominal reactance in ohms. This is the operating point (normally over compensation) that is defined based on the resonance point in the healthy 
     network condition. The impedance is calculated based on nominal voltage divided by position current.
 ancestors:
 - EarthFaultCompensator
-

--- a/spec/ewb/IEC61970/Base/Wires/RotatingMachine.yaml
+++ b/spec/ewb/IEC61970/Base/Wires/RotatingMachine.yaml
@@ -2,20 +2,20 @@ name: RotatingMachine
 description: A rotating machine which may be used as a generator or motor.
 attributes:
 - name: ratedPowerFactor
-  type: Double
+  type: Float
   description: Power factor (nameplate data). It is primarily used for short circuit data exchange according to IEC 60909. The attribute cannot be a negative value.
 - name: ratedS
-  type: Double
+  type: Float
   description: Nameplate apparent power rating for the unit in volt-amperes (VA). The attribute shall have a positive value.
 - name: ratedU
   type: Integer
   description: Rated voltage in volts (nameplate data, Ur in IEC 60909-0). It is primarily used for short circuit data exchange according to IEC 60909. 
     The attribute shall be a positive value.
 - name: p
-  type: Double
+  type: Float
   description: Active power injection in watts. Load sign convention is used, i.e. positive sign means flow out from a node. Starting value for a steady state solution.
 - name: q
-  type: Double
+  type: Float
   description: Reactive power injection in VAr. Load sign convention is used, i.e. positive sign means flow out from a node. Starting value for a steady state solution.
 ancestors:
 - RegulatingCondEq

--- a/spec/ewb/IEC61970/Base/Wires/Switch.yaml
+++ b/spec/ewb/IEC61970/Base/Wires/Switch.yaml
@@ -11,7 +11,7 @@ attributes:
   type: Boolean
   description: The attribute tells if the switch is considered open when used as input to topology processing.
 - name: ratedCurrent
-  type: Integer
+  type: Float
   description: The maximum continuous current carrying capacity in amps governed by the device material and construction.
     The attribute shall be a positive value.
 ancestors:

--- a/spec/ewb/IEC61970/Base/Wires/SynchronousMachine.yaml
+++ b/spec/ewb/IEC61970/Base/Wires/SynchronousMachine.yaml
@@ -2,7 +2,7 @@ name: SynchronousMachine
 description: An electromechanical device that operates with shaft rotating synchronously with the network. It is a single machine operating either as a generator or synchronous condenser or pump.
 attributes:
 - name: baseQ
-  type: Double
+  type: Float
   description: Default base reactive power value in VAr. This value represents the initial reactive power that can be used by any application function.
 - name: condenserP
   type: Integer
@@ -11,52 +11,52 @@ attributes:
   type: Boolean
   description: Indicates whether or not the generator is earthed. Used for short circuit data exchange according to IEC 60909.
 - name: earthingStarPointR
-  type: Double
+  type: Float
   description: Generator star point earthing resistance in Ohms (Re). Used for short circuit data exchange according to IEC 60909.
 - name: earthingStarPointX
-  type: Double
+  type: Float
   description: Generator star point earthing reactance in Ohms (Xe). Used for short circuit data exchange according to IEC 60909.
 - name: ikk
-  type: Double
+  type: Float
   description: "Steady-state short-circuit current (in A for the profile) of generator with compound excitation during 3-phase short circuit. - Ikk=0: Generator with no compound excitation. - Ikk<>0: Generator with compound excitation. Ikk is used to calculate the minimum steady-state short-circuit current for generators with compound excitation. (4.6.1.2 in IEC 60909-0:2001). Used only for single fed short circuit on a generator. (4.3.4.2. in IEC 60909-0:2001)."
 - name: maxQ
-  type: Double
+  type: Float
   description: Maximum reactive power limit in VAr. This is the maximum (nameplate) limit for the unit.
 - name: maxU
   type: Integer
   description: Maximum voltage limit for the unit in volts.
 - name: minQ
-  type: Double
+  type: Float
   description: Minimum reactive power limit for the unit in VAr.
 - name: minU
   type: Integer
   description: Minimum voltage limit for the unit in volts.
 - name: mu
-  type: Double
+  type: Float
   description: Factor to calculate the breaking current (Section 4.5.2.1 in IEC 60909-0). Used only for single fed short circuit on a generator (Section 4.3.4.2. in IEC 60909-0).
 - name: r
-  type: Double
+  type: Float
   description: Equivalent resistance (RG) of generator as a percentage. RG is considered for the calculation of all currents, except for the calculation of the peak current ip. Used for short circuit data exchange according to IEC 60909.
 - name: r0
-  type: Double
+  type: Float
   description: Zero sequence resistance of the synchronous machine as a percentage.
 - name: r2
-  type: Double
+  type: Float
   description: Negative sequence resistance as a percentage.
 - name: satDirectSubtransX
-  type: Double
+  type: Float
   description: Direct-axis subtransient reactance saturated as a percentage, also known as Xd"sat.
 - name: satDirectSyncX
-  type: Double
+  type: Float
   description: Direct-axes saturated synchronous reactance (xdsat); reciprocal of short-circuit ration, as a percentage. Used for short circuit data exchange, only for single fed short circuit on a generator. (4.3.4.2. in IEC 60909-0:2001).
 - name: satDirectTransX
-  type: Double
+  type: Float
   description: Saturated Direct-axis transient reactance as a percentage. The attribute is primarily used for short circuit calculations according to ANSI.
 - name: x0
-  type: Double
+  type: Float
   description: Zero sequence reactance of the synchronous machine as a percentage.
 - name: x2
-  type: Double
+  type: Float
   description: Negative sequence reactance as a percentage.
 - name: type
   type: SynchronousMachineKind
@@ -77,4 +77,3 @@ associations:
   targetDescription: Reactive power rating envelope versus the synchronous machine's active power, in both the generating and motoring modes. For each active 
     power value there is a corresponding high and low reactive power limit value. Typically there will be a separate curve for each coolant condition, such as 
     hydrogen pressure. The Y1 axis values represent reactive minimum and the Y2 axis values represent reactive maximum.
-


### PR DESCRIPTION
# Description

Made the following changes:
* Changed `Switch.ratedCurrent` to a float to support milli-amp ratings of fuses.
* `SynchronousMachine.reactiveCapabilityCurveMRIDs` is now a list of strings. This is what it should have always been (missed in the PR review of the initial change).
* Fixed incorrect use of `Double` instead of `Float` in spec (missed in the PR review of the initial change).

# Associated tasks

- https://github.com/zepben/ewb-sdk-jvm/pull/181

# Test Steps

N/A - any testing will be via the SDK.

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
~- [ ] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.~ No unit tests in gRPC land
~- [ ] I have commented my code in any hard-to-understand or hacky areas.~
~- [ ] I have handled all new warnings generated by the compiler or IDE.~
- [x] I have rebased onto the target branch (usually main).

### Documentation
- [x] I have updated the changelog.
- [x] I have updated any documentation required for these changes.

# Breaking Changes
- [ ] I have considered if this is a breaking change and will communicate it with other team members if so.

Please leave a summary of the breaking changes here. This is useful for the reviewer, but also is useful for communication to the team when merged (e.g. you could copy and paste the summary into slack).

# Screenshots

Remove this section if the change cannot be shown through screenshots. Frontend changes should mostly include this section.
Screenshots can be copy-pasted into Github textboxes and a link will automatically be generated.
Remove this text if you choose to use this section.

| Before | After |
| --- | --- |
| ![image](image-link-here) | ![image](image-link-here) |
