### PR TITLE
[EWB-4472] Add comment to csharp-deploy jobs

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -166,7 +166,12 @@ jobs:
             echo " :boom: There was an error in the \`Upload artifact\` step. Check the logs" >> ${GITHUB_STEP_SUMMARY}
           fi
 
-
+  # CS deploy will deploy the built packages to our NUGET repository.
+  # NUGET_SETTINGS: is a link to our Nuget.Config configuration in ci-utils repository.
+  # ZEPBEN_NUGET_UPLOAD_FEED: is a link to our repository in form of https://<nexus-repo>/repository/nuget-releases/
+  # ZEPBEN_NUGET_FEED_USERNAME: a username for Nexus-Nuget repository, used in Nuget.Config
+  # ZEPBEN_NUGET_FEED_PASSWORD: a password for Nexus-Nuget repository, used in Nuget.Config
+  # ZEPBEN_NUGET_UPLOAD_KEY: a key to use with Nexus repository on package push. 
   cs-deploy:
     needs: release-checks
     runs-on: ubuntu-latest

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -79,6 +79,12 @@ jobs:
           GPG_KEY_PASSWORD: ${{ secrets.GPG_KEY_PASSWORD }}
           POM_PATH: java/pom.xml
 
+  # CS deploy will deploy the built packages to our NUGET repository.
+  # NUGET_SETTINGS: is a link to our Nuget.Config configuration in ci-utils repository.
+  # ZEPBEN_NUGET_UPLOAD_FEED: is a link to our repository in form of https://<nexus-repo>/repository/nuget-releases/
+  # ZEPBEN_NUGET_FEED_USERNAME: a username for Nexus-Nuget repository, used in Nuget.Config
+  # ZEPBEN_NUGET_FEED_PASSWORD: a password for Nexus-Nuget repository, used in Nuget.Config
+  # ZEPBEN_NUGET_UPLOAD_KEY: a key to use with Nexus repository on package push. 
   cs-deploy:
     needs: licence-check-and-protolock-update
     container: mcr.microsoft.com/dotnet/core/sdk:3.1


### PR DESCRIPTION
Add comment to csharp-deploy job in `create-release` and `release-snapshot` workflows to explain the meaning of GH secrets used to deploy packages to Nuget repository.