### PR TITLE
[OPS-260] Fixing if statement

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -86,10 +86,10 @@ jobs:
       - name: Report any failures
         shell: bash
         run: |
-          if [ "${{ steps.deploy.outcome }}" == "failure" ]; then
+          if [ "${{ steps.deploy.outcome }}" = "failure" ]; then
             echo " :boom: There was an error in the \`Maven deploy to Central\` step. Check the logs" >> ${GITHUB_STEP_SUMMARY}
           fi
-          if [ "${{ steps.artifact.outcome }}" == "failure" ]; then
+          if [ "${{ steps.artifact.outcome }}" = "failure" ]; then
             echo " :boom: There was an error in the \`Upload artifact\` step. Check the logs" >> ${GITHUB_STEP_SUMMARY}
           fi
 
@@ -161,10 +161,10 @@ jobs:
       - name: Report any failures
         shell: bash
         run: |
-          if [ "${{ steps.deploy.outcome }}" == "failure" ]; then
+          if [ "${{ steps.deploy.outcome }}" = "failure" ]; then
             echo " :boom: There was an error in the \`Deploy Python\` step. Check the logs" >> ${GITHUB_STEP_SUMMARY}
           fi
-          if [ "${{ steps.artifact.outcome }}" == "failure" ]; then
+          if [ "${{ steps.artifact.outcome }}" = "failure" ]; then
             echo " :boom: There was an error in the \`Upload artifact\` step. Check the logs" >> ${GITHUB_STEP_SUMMARY}
           fi
 
@@ -227,10 +227,10 @@ jobs:
       - name: Report any failures
         shell: bash
         run: |
-          if [ "${{ steps.deploy.outcome }}" == "failure" ]; then
+          if [ "${{ steps.deploy.outcome }}" = "failure" ]; then
             echo " :boom: There was an error in the \`Deploy CSharp\` step. Check the logs" >> ${GITHUB_STEP_SUMMARY}
           fi
-          if [ "${{ steps.artifact.outcome }}" == "failure" ]; then
+          if [ "${{ steps.artifact.outcome }}" = "failure" ]; then
             echo " :boom: There was an error in the \`Upload artifact\` step. Check the logs" >> ${GITHUB_STEP_SUMMARY}
           fi
 
@@ -309,7 +309,7 @@ jobs:
       - name: Report any failures
         shell: bash
         run: |
-          if [ "${{ steps.create_release.outcome }}" == "failure" ]; then
+          if [ "${{ steps.create_release.outcome }}" = "failure" ]; then
             echo " :boom: There was an error in the \`Create Release and upload assets\` step. Check the logs" >> ${GITHUB_STEP_SUMMARY}
           fi
 

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -84,7 +84,7 @@ jobs:
         continue-on-error: true
 
       - name: Report any failures
-        shell: sh {0}
+        shell: bash
         run: |
           if [ "${{ steps.deploy.outcome }}" == "failure" ]; then
             echo " :boom: There was an error in the \`Maven deploy to Central\` step. Check the logs" >> ${GITHUB_STEP_SUMMARY}
@@ -159,7 +159,7 @@ jobs:
         continue-on-error: true
 
       - name: Report any failures
-        shell: sh {0}
+        shell: bash
         run: |
           if [ "${{ steps.deploy.outcome }}" == "failure" ]; then
             echo " :boom: There was an error in the \`Deploy Python\` step. Check the logs" >> ${GITHUB_STEP_SUMMARY}
@@ -225,7 +225,7 @@ jobs:
         continue-on-error: true
 
       - name: Report any failures
-        shell: sh {0}
+        shell: bash
         run: |
           if [ "${{ steps.deploy.outcome }}" == "failure" ]; then
             echo " :boom: There was an error in the \`Deploy CSharp\` step. Check the logs" >> ${GITHUB_STEP_SUMMARY}
@@ -307,7 +307,7 @@ jobs:
         continue-on-error: true
 
       - name: Report any failures
-        shell: sh {0}
+        shell: bash
         run: |
           if [ "${{ steps.create_release.outcome }}" == "failure" ]; then
             echo " :boom: There was an error in the \`Create Release and upload assets\` step. Check the logs" >> ${GITHUB_STEP_SUMMARY}


### PR DESCRIPTION
In POSIX sh, the if "equal" statement has to use a single '=' char, whereas bash allows both single and double use. Using single '=' and bumping the running shell to bash in our cases just to be on the safe side.

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
~- [ ] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.~
~- [ ] I have commented my code in any hard-to-understand or hacky areas.~
~- [ ] I have handled all new warnings generated by the compiler or IDE.~
- [x] I have rebased onto the target branch (usually main).

### Documentation
~- [ ] I have updated the changelog.~
~- [ ] I have updated any documentation required for these changes.~

No documentation changes are needed.

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members if so.

This is not a breaking change.
