### PR TITLE
Fix ns python compatibility

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,7 @@
 # Zepben Protobuf and GRPC definitions
 ## [0.32.0] - UNRELEASED
 ### Breaking Changes
-* Renamed `from` and `to` fields in the `GetCurrentStatesRequest` message to `from_timestamp` and `to_timestamp` to ensure compatibility with Python's reserved keywords.
+* Renamed `from` and `to` fields in the `GetCurrentStatesRequest` message to `fromTimestamp` and `toTimestamp` to ensure compatibility with Python's reserved keywords.
 
 ### New Features
 * None.

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,7 @@
 # Zepben Protobuf and GRPC definitions
 ## [0.32.0] - UNRELEASED
 ### Breaking Changes
-* None.
+* Renamed `from` and `to` fields in the `GetCurrentStatesRequest` message to `from_timestamp` and `to_timestamp` to ensure compatibility with Python's reserved keywords.
 
 ### New Features
 * None.
@@ -10,7 +10,7 @@
 * None.
 
 ### Fixes
-* Renamed `from` and `to` fields in the `GetCurrentStatesRequest` message to `from_timestamp` and `to_timestamp` to ensure compatibility with Python's reserved keywords.
+* None.
 
 ### Notes
 * None.

--- a/changelog.md
+++ b/changelog.md
@@ -10,7 +10,7 @@
 * None.
 
 ### Fixes
-* None.
+* Renamed `from` and `to` fields in the `GetCurrentStatesRequest` message to `from_timestamp` and `to_timestamp` to ensure compatibility with Python's reserved keywords.
 
 ### Notes
 * None.

--- a/proto/zepben/proto.lock
+++ b/proto/zepben/proto.lock
@@ -14572,12 +14572,12 @@
               },
               {
                 "id": 2,
-                "name": "from_timestamp",
+                "name": "fromTimestamp",
                 "type": "google.protobuf.Timestamp"
               },
               {
                 "id": 3,
-                "name": "to_timestamp",
+                "name": "toTimestamp",
                 "type": "google.protobuf.Timestamp"
               }
             ]

--- a/proto/zepben/proto.lock
+++ b/proto/zepben/proto.lock
@@ -14572,12 +14572,12 @@
               },
               {
                 "id": 2,
-                "name": "from",
+                "name": "from_timestamp",
                 "type": "google.protobuf.Timestamp"
               },
               {
                 "id": 3,
-                "name": "to",
+                "name": "to_timestamp",
                 "type": "google.protobuf.Timestamp"
               }
             ]

--- a/proto/zepben/protobuf/ns/network-state-requests.proto
+++ b/proto/zepben/protobuf/ns/network-state-requests.proto
@@ -46,11 +46,11 @@ message GetCurrentStatesRequest {
     /**
      * The timestamp for the earliest requested event.
      */
-    google.protobuf.Timestamp from_timestamp = 2;
+    google.protobuf.Timestamp fromTimestamp = 2;
 
     /**
      * The timestamp for the latest requested event.
      */
-    google.protobuf.Timestamp to_timestamp = 3;
+    google.protobuf.Timestamp toTimestamp = 3;
 
 }

--- a/proto/zepben/protobuf/ns/network-state-requests.proto
+++ b/proto/zepben/protobuf/ns/network-state-requests.proto
@@ -46,11 +46,11 @@ message GetCurrentStatesRequest {
     /**
      * The timestamp for the earliest requested event.
      */
-    google.protobuf.Timestamp from = 2;
+    google.protobuf.Timestamp from_timestamp = 2;
 
     /**
      * The timestamp for the latest requested event.
      */
-    google.protobuf.Timestamp to = 3;
+    google.protobuf.Timestamp to_timestamp = 3;
 
 }


### PR DESCRIPTION
# Description

Renamed `from` and `to` fields in the `GetCurrentStatesRequest` message to `fromTimestamp` and `toTimestamp` to ensure compatibility with Python's reserved keywords

# Associated tasks
None

# Test Steps

N/A

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [ ] ~I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.~
- [ ] ~I have commented my code in any hard-to-understand or hacky areas.~
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).

### Documentation
- [x] I have updated the changelog.
- [ ] ~I have updated any documentation required for these changes.~

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members if so.

Java SDK needs to be updated with the new field names.
