### PR TITLE
[OPS-278] Update github actions to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   licence-and-protolock-check:
     runs-on: ubuntu-latest
-    container: zepben/pipeline-basic:5.7.4
+    container: zepben/pipeline-basic
     steps:
       - uses: actions/checkout@v4
 
@@ -15,13 +15,13 @@ jobs:
           apk add --no-cache tar
 
       - name: Cache licence-check
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /lc
           key: lcc
 
       - name: Cache protolock
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /protolock
           key: pbc
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Cache maven deps
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /maven
           key: maven
@@ -64,7 +64,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Cache C# deps
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /root/.nuget/packages
           key: cs
@@ -82,7 +82,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Cache python deps
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /pipcache
           key: pip

--- a/.github/workflows/create-hotfix-branch.yml
+++ b/.github/workflows/create-hotfix-branch.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   create-hotfix-branch:
     runs-on: ubuntu-latest
-    container: zepben/pipeline-basic:5.7.4
+    container: zepben/pipeline-basic
     env:
       DEBUG: ${{ secrets.DEBUG }}
       GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}

--- a/.github/workflows/create-lts-branch.yml
+++ b/.github/workflows/create-lts-branch.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   create-lts-branch:
     runs-on: ubuntu-latest
-    container: zepben/pipeline-basic:5.7.4
+    container: zepben/pipeline-basic
     env:
       DEBUG: ${{ secrets.DEBUG }}
       GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -5,7 +5,7 @@ on: workflow_dispatch
 jobs:
   release-checks:
     runs-on: ubuntu-latest
-    container: zepben/pipeline-basic:5.7.4
+    container: zepben/pipeline-basic
     outputs:
       version: ${{ steps.check.outputs.release-version }}
     env:
@@ -58,7 +58,7 @@ jobs:
           ref: release
 
       - name: Cache maven deps
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /maven
           key: maven
@@ -77,7 +77,7 @@ jobs:
 
       - name: Upload artifact
         id: artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: java
           path: ${{ steps.deploy.outputs.artifact-path }}
@@ -115,7 +115,7 @@ jobs:
         shell: sh
 
       - name: Cache python deps
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: pip
@@ -151,7 +151,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         id: artifact
         with:
           name: python
@@ -192,7 +192,7 @@ jobs:
           ref: release
 
       - name: Cache C# deps
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /root/.nuget/packages
           key: cs
@@ -217,7 +217,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         id: artifact
         with:
           name: csharp
@@ -237,7 +237,7 @@ jobs:
   finalise:
     needs: [java-deploy, python-deploy, cs-deploy]
     runs-on: ubuntu-latest
-    container: zepben/pipeline-basic:5.7.4
+    container: zepben/pipeline-basic
     steps:
       - uses: actions/checkout@v4
         with:
@@ -275,17 +275,17 @@ jobs:
         shell: bash
 
       - name: Download java artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: java
 
       - name: Download csharp artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: csharp
 
       - name: Download python artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: python
                   
@@ -316,7 +316,7 @@ jobs:
   update-version:
     needs: finalise
     runs-on: ubuntu-latest
-    container: zepben/pipeline-basic:5.7.4
+    container: zepben/pipeline-basic
     env:
       GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
       NEXUS_MAVEN_REPO: ${{ secrets.NEXUS_MAVEN_REPO }}

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   licence-check-and-protolock-update:
     runs-on: ubuntu-latest
-    container: zepben/pipeline-basic:5.7.4
+    container: zepben/pipeline-basic
     steps:
       - uses: actions/checkout@v4
         with:
@@ -27,13 +27,13 @@ jobs:
           apk add --no-cache tar
 
       - name: Cache licence-check
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /lc
           key: lcc
 
       - name: Cache protolock
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /protolock
           key: pbc
@@ -64,7 +64,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Cache maven deps
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /maven
           key: maven
@@ -99,7 +99,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Cache C# deps
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /root/.nuget/packages
           key: cs
@@ -134,7 +134,7 @@ jobs:
 
 
       - name: Cache python deps
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: pip
@@ -162,7 +162,7 @@ jobs:
 
   update-snapshot-version:
     needs: [python-deploy, cs-deploy, java-deploy]
-    container: zepben/pipeline-basic:5.7.4
+    container: zepben/pipeline-basic
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}


### PR DESCRIPTION
# Description

Github is planning to deprecate `v3` version of a few actions in December, and forcefully fail the workflow runs. This change is bumping the required actions to v4, as well as dropping labels from `pipeline-basic` to use the latest version.

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
~- [ ] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.~
~- [ ] I have commented my code in any hard-to-understand or hacky areas.~
~- [ ] I have handled all new warnings generated by the compiler or IDE.~
- [x] I have rebased onto the target branch (usually main).

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members if so.

This is not a breaking change.