### PR TITLE
[DEV-1968] current state container enhancements.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ### Breaking Changes
 * Removed the `ProcessingPaused` current state status response due to pause/resume support being dropped.
 * Corrected `AcLineSegment.perLengthSequenceImpedanceMRID` to `AcLineSegment.perLengthImpedanceMRID`.
+* Removed `getCurrentEquipmentForFeeder` as its functionality is now incorporated in `getEquipmentForContainers`.
 
 ### New Features
 * Added New Classes
@@ -34,6 +35,8 @@
     shunt compensators, or battery units.
 * Added repeated attribute of `batteryControls` to `BatteryUnit`.
 * Added repeated attribute of `endDeviceFunctions` to `EndDevice`.
+* Added the energized relationship for the current state of network between `Feeder` and `LvFeeder`.
+* Updated `getEquipmentForContainers` to allow requesting normal, current or all equipments.
 
 ### Fixes
 * None.

--- a/proto/zepben/proto.lock
+++ b/proto/zepben/proto.lock
@@ -14544,21 +14544,6 @@
             ]
           },
           {
-            "name": "GetCurrentEquipmentForFeederRequest",
-            "fields": [
-              {
-                "id": 1,
-                "name": "messageId",
-                "type": "int64"
-              },
-              {
-                "id": 2,
-                "name": "mrid",
-                "type": "string"
-              }
-            ]
-          },
-          {
             "name": "GetEquipmentForRestrictionRequest",
             "fields": [
               {
@@ -14691,22 +14676,6 @@
             ]
           },
           {
-            "name": "GetCurrentEquipmentForFeederResponse",
-            "fields": [
-              {
-                "id": 1,
-                "name": "messageId",
-                "type": "int64"
-              },
-              {
-                "id": 2,
-                "name": "identifiedObjects",
-                "type": "NetworkIdentifiedObject",
-                "is_repeated": true
-              }
-            ]
-          },
-          {
             "name": "GetEquipmentForRestrictionResponse",
             "fields": [
               {
@@ -14807,12 +14776,6 @@
                 "in_type": "GetEquipmentForContainersRequest",
                 "out_type": "GetEquipmentForContainersResponse",
                 "in_streamed": true,
-                "out_streamed": true
-              },
-              {
-                "name": "getCurrentEquipmentForFeeder",
-                "in_type": "GetCurrentEquipmentForFeederRequest",
-                "out_type": "GetCurrentEquipmentForFeederResponse",
                 "out_streamed": true
               },
               {

--- a/proto/zepben/proto.lock
+++ b/proto/zepben/proto.lock
@@ -10961,7 +10961,7 @@
               },
               {
                 "id": 4,
-                "name": "currentlyEnergizingFeedersMRIDs",
+                "name": "currentlyEnergizingFeederMRIDs",
                 "type": "string",
                 "is_repeated": true
               }

--- a/proto/zepben/proto.lock
+++ b/proto/zepben/proto.lock
@@ -14469,7 +14469,7 @@
             ]
           },
           {
-            "name": "EnergizedNetworkState",
+            "name": "NetworkState",
             "enum_fields": [
               {
                 "name": "ALL_NETWORK_STATE"
@@ -14538,8 +14538,8 @@
               },
               {
                 "id": 5,
-                "name": "energizedNetworkState",
-                "type": "EnergizedNetworkState"
+                "name": "networkState",
+                "type": "NetworkState"
               }
             ]
           },

--- a/proto/zepben/proto.lock
+++ b/proto/zepben/proto.lock
@@ -3998,6 +3998,12 @@
                 "name": "normalEnergizedLvFeederMRIDs",
                 "type": "string",
                 "is_repeated": true
+              },
+              {
+                "id": 5,
+                "name": "CurrentlyEnergizedLvFeedersMRIDs",
+                "type": "string",
+                "is_repeated": true
               }
             ]
           }
@@ -10952,6 +10958,12 @@
                 "name": "normalEnergizingFeederMRIDs",
                 "type": "string",
                 "is_repeated": true
+              },
+              {
+                "id": 4,
+                "name": "currentlyEnergizingFeedersMRIDs",
+                "type": "string",
+                "is_repeated": true
               }
             ]
           }
@@ -14455,6 +14467,22 @@
                 "integer": 2
               }
             ]
+          },
+          {
+            "name": "EnergizedNetworkState",
+            "enum_fields": [
+              {
+                "name": "ALL_NETWORK_STATE"
+              },
+              {
+                "name": "NORMAL_NETWORK_STATE",
+                "integer": 1
+              },
+              {
+                "name": "CURRENT_NETWORK_STATE",
+                "integer": 2
+              }
+            ]
           }
         ],
         "messages": [
@@ -14507,6 +14535,11 @@
                 "id": 4,
                 "name": "includeEnergizedContainers",
                 "type": "IncludedEnergizedContainers"
+              },
+              {
+                "id": 5,
+                "name": "energizedNetworkState",
+                "type": "EnergizedNetworkState"
               }
             ]
           },

--- a/proto/zepben/proto.lock
+++ b/proto/zepben/proto.lock
@@ -4001,7 +4001,7 @@
               },
               {
                 "id": 5,
-                "name": "CurrentlyEnergizedLvFeedersMRIDs",
+                "name": "currentlyEnergizedLvFeedersMRIDs",
                 "type": "string",
                 "is_repeated": true
               }

--- a/proto/zepben/protobuf/cim/iec61970/base/core/Feeder.proto
+++ b/proto/zepben/protobuf/cim/iec61970/base/core/Feeder.proto
@@ -47,6 +47,6 @@ message Feeder {
     /**
      * mRID references to the LV feeders that are currently energized by the feeder.
      */
-    repeated string CurrentlyEnergizedLvFeedersMRIDs = 5;
+    repeated string currentlyEnergizedLvFeedersMRIDs = 5;
 
 }

--- a/proto/zepben/protobuf/cim/iec61970/base/core/Feeder.proto
+++ b/proto/zepben/protobuf/cim/iec61970/base/core/Feeder.proto
@@ -44,4 +44,9 @@ message Feeder {
      */
     repeated string normalEnergizedLvFeederMRIDs = 4;
 
+    /**
+     * mRID references to the LV feeders that are currently energized by the feeder.
+     */
+    repeated string CurrentlyEnergizedLvFeedersMRIDs = 5;
+
 }

--- a/proto/zepben/protobuf/cim/iec61970/infiec61970/feeder/LvFeeder.proto
+++ b/proto/zepben/protobuf/cim/iec61970/infiec61970/feeder/LvFeeder.proto
@@ -37,6 +37,6 @@ message LvFeeder {
     /**
      * mRID reference to the HV/MV feeders that energize this LV feeder in the current state of the network.
      */
-    repeated string currentlyEnergizingFeedersMRIDs = 4;
+    repeated string currentlyEnergizingFeederMRIDs = 4;
 
 }

--- a/proto/zepben/protobuf/cim/iec61970/infiec61970/feeder/LvFeeder.proto
+++ b/proto/zepben/protobuf/cim/iec61970/infiec61970/feeder/LvFeeder.proto
@@ -34,4 +34,9 @@ message LvFeeder {
      */
     repeated string normalEnergizingFeederMRIDs = 3;
 
+    /**
+     * mRID reference to the HV/MV feeders that energize this LV feeder in the current state of the network.
+     */
+    repeated string currentlyEnergizingFeedersMRIDs = 4;
+
 }

--- a/proto/zepben/protobuf/nc/nc-requests.proto
+++ b/proto/zepben/protobuf/nc/nc-requests.proto
@@ -31,7 +31,7 @@ enum IncludedEnergizedContainers {
     INCLUDE_ENERGIZED_FEEDERS = 1;
     INCLUDE_ENERGIZED_LV_FEEDERS = 2;
 }
-enum EnergizedNetworkState {
+enum NetworkState {
     ALL_NETWORK_STATE = 0;
     NORMAL_NETWORK_STATE = 1;
     CURRENT_NETWORK_STATE = 2;
@@ -54,8 +54,8 @@ message GetEquipmentForContainersRequest {
     // in the response.
     IncludedEnergizedContainers includeEnergizedContainers = 4;
 
-    // Rule for which energized containers to include based on the state of the network
-    EnergizedNetworkState energizedNetworkState = 5;
+    // Rule for equipments to return based on the state of the network
+    NetworkState networkState = 5;
 }
 
 message GetEquipmentForRestrictionRequest {

--- a/proto/zepben/protobuf/nc/nc-requests.proto
+++ b/proto/zepben/protobuf/nc/nc-requests.proto
@@ -31,6 +31,11 @@ enum IncludedEnergizedContainers {
     INCLUDE_ENERGIZED_FEEDERS = 1;
     INCLUDE_ENERGIZED_LV_FEEDERS = 2;
 }
+enum EnergizedNetworkState {
+    ALL_NETWORK_STATE = 0;
+    NORMAL_NETWORK_STATE = 1;
+    CURRENT_NETWORK_STATE = 2;
+}
 message GetEquipmentForContainersRequest {
     int64 messageId = 1;
 
@@ -48,6 +53,9 @@ message GetEquipmentForContainersRequest {
     // all equipment belonging to that substation, its powered feeders, and those feeders' LV feeders are included
     // in the response.
     IncludedEnergizedContainers includeEnergizedContainers = 4;
+
+    // Rule for which energized containers to include based on the state of the network
+    EnergizedNetworkState energizedNetworkState = 5;
 }
 
 message GetCurrentEquipmentForFeederRequest {

--- a/proto/zepben/protobuf/nc/nc-requests.proto
+++ b/proto/zepben/protobuf/nc/nc-requests.proto
@@ -58,13 +58,6 @@ message GetEquipmentForContainersRequest {
     EnergizedNetworkState energizedNetworkState = 5;
 }
 
-message GetCurrentEquipmentForFeederRequest {
-    int64 messageId = 1;
-
-    // mRID of the Feeder to retrieve Equipment for.
-    string mrid = 2;
-}
-
 message GetEquipmentForRestrictionRequest {
     int64 messageId = 1;
 

--- a/proto/zepben/protobuf/nc/nc-responses.proto
+++ b/proto/zepben/protobuf/nc/nc-responses.proto
@@ -41,11 +41,6 @@ message GetEquipmentForContainersResponse {
     repeated NetworkIdentifiedObject identifiedObjects = 2;
 }
 
-message GetCurrentEquipmentForFeederResponse {
-    int64 messageId = 1;
-    repeated NetworkIdentifiedObject identifiedObjects = 2;
-}
-
 message GetEquipmentForRestrictionResponse {
     int64 messageId = 1;
     repeated NetworkIdentifiedObject identifiedObjects = 2;

--- a/proto/zepben/protobuf/nc/nc.proto
+++ b/proto/zepben/protobuf/nc/nc.proto
@@ -29,9 +29,6 @@ service NetworkConsumer {
     // Get an EquipmentContainer's equipment
     rpc getEquipmentForContainers (stream GetEquipmentForContainersRequest) returns (stream GetEquipmentForContainersResponse);
 
-    // Get an EquipmentContainer's current equipment
-    rpc getCurrentEquipmentForFeeder (GetCurrentEquipmentForFeederRequest) returns (stream GetCurrentEquipmentForFeederResponse);
-
     // Get an OperationalRestriction's equipment
     rpc getEquipmentForRestriction (GetEquipmentForRestrictionRequest) returns (stream GetEquipmentForRestrictionResponse);
 

--- a/spec/ewb/IEC61970/Base/Core/Feeder.yaml
+++ b/spec/ewb/IEC61970/Base/Core/Feeder.yaml
@@ -23,5 +23,15 @@ associations:
   target: LvFeeder
   sourceCardinality: 0..1
   sourceName: NormalEnergizingFeeders
+  sourceDescription: The HV/MV feeders that energize the LV feeder.
   targetCardinality: 0..*
   targetName: NormalEnergizedLvFeeders
+  targetDescription: The LV feeders that are normally energized by this feeder.
+- source: Feeder
+  target: LvFeeder
+  sourceCardinality: 0..1
+  sourceName: CurrentlyEnergizingFeeders
+  sourceDescription: The HV/MV feeders that energize the LV feeder in the current state of the network.
+  targetCardinality: 0..*
+  targetName: CurrentlyEnergizedLvFeeders
+  targetDescription: The LV feeders that are currently energized by this feeder.

--- a/spec/ewb/extensions/IEC61970/InfIEC61970/Feeder/LvFeeder.yaml
+++ b/spec/ewb/extensions/IEC61970/InfIEC61970/Feeder/LvFeeder.yaml
@@ -12,6 +12,14 @@ associations:
   targetName: NormalEnergizingFeeders
   targetDescription: The HV/MV feeders that energize this LV feeder.
 - source: LvFeeder
+  target: Feeder
+  sourceCardinality: 0..*
+  sourceName: CurrentlyEnergizedLvFeeders
+  sourceDescription: The LV feeders that are currently energized by the feeder.
+  targetCardinality: 0..*
+  targetName: CurrentlyEnergizingFeeders
+  targetDescription: The HV/MV feeders that energize this LV feeder in the current state of the network.
+- source: LvFeeder
   target: Equipment
   sourceCardinality: 0..*
   sourceName: NormalLvFeeders


### PR DESCRIPTION
# Description

Added energizing relationship between `Feeder` and `LvFeeder` for the current state of the network. 

Also made changes in `zepben.proto.nc` to support getting the the current equipment containers for all container types.

# Associated tasks

- https://github.com/zepben/ewb-grpc/pull/121
- https://github.com/zepben/ewb-network-routes/pull/170

# Test Steps

N/A

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [ ] ~I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.~
- [ ] ~I have commented my code in any hard-to-understand or hacky areas.~
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).

### Documentation
- [x] I have updated the changelog.
- [x] I have updated any documentation required for these changes.

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members if so.

Removed `getCurrentEquipmentForFeeder` as its functionality is now incorporated in `getEquipmentForContainers`.