### PR TITLE
[DEV-2054] Removed the `ProcessingPaused` current state status

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,7 @@
 # Zepben Protobuf and GRPC definitions
 ## [0.33.0] - UNRELEASED
 ### Breaking Changes
-* None.
+* Removed the `ProcessingPaused` current state status response due to pause/resume support being dropped.
 
 ### New Features
 * None.

--- a/proto/zepben/proto.lock
+++ b/proto/zepben/proto.lock
@@ -14446,16 +14446,6 @@
             "name": "BatchSuccessful"
           },
           {
-            "name": "ProcessingPaused",
-            "fields": [
-              {
-                "id": 2,
-                "name": "since",
-                "type": "google.protobuf.Timestamp"
-              }
-            ]
-          },
-          {
             "name": "BatchFailure",
             "fields": [
               {
@@ -14647,18 +14637,12 @@
               },
               {
                 "id": 3,
-                "name": "paused",
-                "type": "data.ProcessingPaused",
-                "oneof_parent": "status"
-              },
-              {
-                "id": 4,
                 "name": "failure",
                 "type": "data.BatchFailure",
                 "oneof_parent": "status"
               },
               {
-                "id": 5,
+                "id": 4,
                 "name": "notProcessed",
                 "type": "data.BatchNotProcessed",
                 "oneof_parent": "status"

--- a/proto/zepben/protobuf/ns/data/change-status.proto
+++ b/proto/zepben/protobuf/ns/data/change-status.proto
@@ -21,19 +21,6 @@ message BatchSuccessful {
 }
 
 /**
- * A response indicating that current state events are not currently being processed. There is no need to retry these,
- * the missed events will be requested when processing resumes.
- */
-message ProcessingPaused {
-
-    /**
-     * The timestamp when the processing was paused.
-     */
-    google.protobuf.Timestamp since = 2;
-
-}
-
-/**
  * A response indicating one or more items in the batch couldn't be applied.
  */
 message BatchFailure {

--- a/proto/zepben/protobuf/ns/network-state-responses.proto
+++ b/proto/zepben/protobuf/ns/network-state-responses.proto
@@ -31,9 +31,8 @@ message SetCurrentStatesResponse {
      */
     oneof status {
         data.BatchSuccessful success = 2;
-        data.ProcessingPaused paused = 3;
-        data.BatchFailure failure = 4;
-        data.BatchNotProcessed notProcessed = 5;
+        data.BatchFailure failure = 3;
+        data.BatchNotProcessed notProcessed = 4;
     }
 
 }


### PR DESCRIPTION
# Description

Removed the `ProcessingPaused` current state status response due to pause/resume support being dropped.

# Test Steps

None.

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
~- [ ] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.~
~- [ ] I have commented my code in any hard-to-understand or hacky areas.~
~- [ ] I have handled all new warnings generated by the compiler or IDE.~
- [x] I have rebased onto the target branch (usually main).

### Documentation
- [x] I have updated the changelog.
~- [ ] I have updated any documentation required for these changes.~

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members if so.

Breaking change for current state processes, but will only have an impact on people using the protobuf messages directly beyond the SDK (no one)